### PR TITLE
Display only public posts in the digest

### DIFF
--- a/api.py
+++ b/api.py
@@ -38,6 +38,9 @@ def fetch_posts_and_boosts(
             filtered_response = response
 
         for post in filtered_response:
+            if post["visibility"] != "public":
+                continue
+
             total_posts_seen += 1
 
             boost = False


### PR DESCRIPTION
This PR restricts the digest to include only public posts.

**Motivation:**

This `mastodon_digest` project, since it runs on GitHub Actions and publishes to GitHub Pages, makes posts from the user's timeline available publicly. (It's also trivial to discover who's using this tool, and view their digests, via [the list of project forks](https://github.com/mauforonda/mastodon_digest/network/members).)

The code as originally written allows all posts, regardless of their visibility setting, to appear in these public digests. It's not even clear to me if direct messages are filtered out.

I, and other users on my Mastodon instance, have seen private and unlisted posts become publicly available because another user on the server ran `mastodon_digest` and published it to GitHub Pages.

The only correct and acceptable behavior, given that this code publishes digests to public and discoverable pages, is to include only public posts in the digest.